### PR TITLE
Upgrade Zendesk SDK version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+.idea/workspace.xml

--- a/RNZendeskChat.podspec
+++ b/RNZendeskChat.podspec
@@ -18,8 +18,9 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'ZendeskAnswerBotSDK'
-  s.dependency 'ZendeskSupportSDK', '~> 5.0.5'
-  s.dependency 'ZendeskChatSDK'
+  s.dependency 'ZendeskAnswerBotSDK', '~> 2.1.3'
+  s.dependency 'ZendeskSupportSDK', '~> 5.3.0'
+  s.dependency 'ZendeskChatSDK' '~> 2.11.1'
+  s.dependency 'ZendeskMessagingAPISDK', '~> 3.8.2'
   s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,9 +33,9 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api group: 'com.zendesk', name: 'chat', version: '3.1.0'
-    api group: 'com.zendesk', name: 'answerbot', version: '3.0.1'
-    api group: 'com.zendesk', name: 'messaging', version: '5.1.0'
-    api group: 'com.zendesk', name: 'support', version: '5.0.2'
+    api group: 'com.zendesk', name: 'chat', version: '3.3.2'
+    api group: 'com.zendesk', name: 'answerbot', version: '3.0.4'
+    api group: 'com.zendesk', name: 'messaging', version: '5.2.2'
+    api group: 'com.zendesk', name: 'support', version: '5.0.5'
 }
-  
+

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -189,9 +189,7 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void startChat(ReadableMap options) {
-    setUserIdentity(options);
     setVisitorInfo(options);
-    setUserIdentity(options);
     String botName = getString(options,"botName");
     botName = botName == null ? "bot name" : botName;
     ChatConfiguration chatConfiguration = ChatConfiguration.builder()

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -147,10 +147,19 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
       Identity identity = new JwtIdentity(token);
       Zendesk.INSTANCE.setIdentity(identity);
     } else {
-      String name = options.getString("name");
-      String email = options.getString("email");
-      Identity identity = new AnonymousIdentity.Builder()
-        .withNameIdentifier(name).withEmailIdentifier(email).build();
+      String name = getString(options,"name");
+      String email = getString(options,"email");
+
+      AnonymousIdentity.Builder builder = new AnonymousIdentity.Builder();
+
+      if(name != null){
+          builder.withNameIdentifier(name);
+      }
+      if(email != null){
+          builder.withEmailIdentifier(email);
+      }
+
+      Identity identity = builder.build();
       Zendesk.INSTANCE.setIdentity(identity);
     }
     checkIdentity();

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -14,6 +14,9 @@ import com.facebook.react.bridge.ReadableMap;
 import com.zendesk.logger.Logger;
 
 import java.lang.String;
+import java.util.ArrayList;
+import java.util.List;
+
 import zendesk.chat.Chat;
 import zendesk.chat.ChatConfiguration;
 import zendesk.chat.ChatEngine;
@@ -22,17 +25,20 @@ import zendesk.chat.ProfileProvider;
 import zendesk.chat.PushNotificationsProvider;
 import zendesk.chat.Providers;
 import zendesk.chat.VisitorInfo;
+import zendesk.configurations.Configuration;
 import zendesk.core.JwtIdentity;
 import zendesk.core.AnonymousIdentity;
 import zendesk.core.Identity;
 import zendesk.messaging.MessagingActivity;
 import zendesk.core.Zendesk;
+import zendesk.support.CustomField;
 import zendesk.support.Support;
 import zendesk.support.guide.HelpCenterActivity;
 import zendesk.support.guide.ViewArticleActivity;
 import zendesk.answerbot.AnswerBot;
 import zendesk.answerbot.AnswerBotEngine;
 import zendesk.support.SupportEngine;
+import zendesk.support.request.RequestActivity;
 
 public class RNZendeskChat extends ReactContextBaseJavaModule {
 
@@ -49,12 +55,21 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
     return "RNZendeskChat";
   }
 
-  private String getBotName(ReadableMap options){
-    if(options.hasKey("botName")){
-      return options.getString("botName");
+  /* helper methods */
+  private Boolean getBoolean(ReadableMap options, String key){
+    if(options.hasKey(key)){
+      return options.getBoolean(key);
     }
-    return "Chat Bot";
+    return null;
   }
+
+  private String getString(ReadableMap options, String key){
+    if(options.hasKey(key)){
+      return options.getString(key);
+    }
+    return null;
+  }
+
 
   @ReactMethod
   public void setVisitorInfo(ReadableMap options) {
@@ -75,19 +90,23 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
       return;
     }
     VisitorInfo.Builder builder = VisitorInfo.builder();
-    if (options.hasKey("name")) {
-      builder = builder.withName(options.getString("name"));
+    String name = getString(options,"name");
+    String email = getString(options,"email");
+    String phone = getString(options,"phone");
+    String department = getString(options,"department");
+    if (name != null) {
+      builder = builder.withName(name);
     }
-    if (options.hasKey("email")) {
-      builder = builder.withEmail(options.getString("email"));
+    if (email != null) {
+      builder = builder.withEmail(email);
     }
-    if (options.hasKey("phone")) {
-      builder = builder.withPhoneNumber(options.getString("phone"));
+    if (phone != null) {
+      builder = builder.withPhoneNumber(phone);
     }
     VisitorInfo visitorInfo = builder.build();
     profileProvider.setVisitorInfo(visitorInfo, null);
-    if (options.hasKey("department"))
-      chatProvider.setDepartment(options.getString("department"), null);
+    if (department != null)
+      chatProvider.setDepartment(department, null);
 
   }
 
@@ -123,8 +142,9 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void setUserIdentity(ReadableMap options) {
-    if (options.hasKey("token")) {
-      Identity identity = new JwtIdentity(options.getString("token"));
+    String token = getString(options,"token");
+    if (token != null) {
+      Identity identity = new JwtIdentity(token);
       Zendesk.INSTANCE.setIdentity(identity);
     } else {
       String name = options.getString("name");
@@ -139,11 +159,22 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
   @ReactMethod
   public void showHelpCenter(ReadableMap options) {
     Activity activity = getCurrentActivity();
-    if (options.hasKey("withChat")) {
+    /*
+    // config must be passed as 2nd parameter to show method
+    List<CustomField> customFields = new ArrayList<>();
+    customFields.add(new CustomField(360028434358L, "testValoreDaApp"));
+    Configuration config = RequestActivity.builder()
+      .withCustomFields(customFields)
+      .withTags("tag1","tag2")
+      .config();
+     */
+    Boolean withChat = getBoolean(options,"withChat");
+    Boolean disableTicketCreation = getBoolean(options,"withChat");
+    if (withChat) {
       HelpCenterActivity.builder()
         .withEngines(ChatEngine.engine())
         .show(activity);
-    } else if (options.hasKey("disableTicketCreation")) {
+    } else if (disableTicketCreation) {
       HelpCenterActivity.builder()
         .withContactUsButtonVisible(false)
         .withShowConversationsMenuButton(false)
@@ -161,7 +192,8 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
     setUserIdentity(options);
     setVisitorInfo(options);
     setUserIdentity(options);
-    String botName = getBotName(options);
+    String botName = getString(options,"botName");
+    botName = botName == null ? "bot name" : botName;
     ChatConfiguration chatConfiguration = ChatConfiguration.builder()
       .withAgentAvailabilityEnabled(true)
       .withOfflineFormEnabled(true)

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,11 +50,7 @@ declare module 'io-react-native-zendesk' {
     url: string,
   }
 
-  interface UserInfo {
-    // user's name
-    name: string
-    // user's email
-    email: string
+  interface UserInfo extends AnonymousIdentity{
     // user's phone
     phone?: number
     // department to redirect the chat
@@ -69,9 +65,9 @@ declare module 'io-react-native-zendesk' {
 
   interface AnonymousIdentity {
     // user's name
-    name: string
+    name?: string
     // user's email
-    email: string
+    email?: string
   }
 
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'react-native-zendesk-v2' {
+declare module 'io-react-native-zendesk' {
 
   // function to display chat box
   export function startChat(chatOptions: ChatOptions): void;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "zendesk unified sdkv2"
   ],
   "homepage": "https://github.com/pagopa/io-react-native-zendesk.git",
-  "author": "forked by PagoPA S.p.A - origina author @Saranshmalik",
+  "author": "forked by PagoPA S.p.A - original author @Saranshmalik",
   "license": "MIT",
   "peerDependencies": {
     "react": "~16.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-zendesk-v2",
+  "name": "io-react-native-zendesk",
   "version": "0.3.4",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zendesk-v2",
-  "version": "0.2.1",
+  "version": "0.3.4",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Saranshmalik/react-native-zendesk.git"
+    "url": "https://github.com/pagopa/io-react-native-zendesk"
   },
   "keywords": [
     "react-native",
@@ -19,8 +19,8 @@
     "chat",
     "zendesk unified sdkv2"
   ],
-  "homepage": "https://github.com/Saranshmalik/react-native-zendesk.git",
-  "author": "Saranshmalik",
+  "homepage": "https://github.com/pagopa/io-react-native-zendesk.git",
+  "author": "forked by PagoPA S.p.A - origina author @Saranshmalik",
   "license": "MIT",
   "peerDependencies": {
     "react": "~16.11.0",


### PR DESCRIPTION
This PR ugrade the Zendesk SDK both in Android and IOS:

**Android**
- `chat`: from 3.1.0 to **3.3.2**
- `answerbot`: from 3.0.1 to **3.0.4**
- `messaging`: from 5.1.0 to **5.2.2**
- `support`: from 5.0.2 to **5.0.5**

**IOS**

- `ZendeskAnswerBotSDK`: from 2.0.5 to **2.1.3**
- `ZendeskSupportSDK`: from 5.0.5 to **5.3.0**
- `ZendeskChatSDK`: from 2.7.0 to **2.11.1**
- `ZendeskMessagingAPISDK`: from 3.6.0 to **3.8.2**