### PR TITLE
Manage support operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+.idea/workspace.xml

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -189,9 +189,7 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void startChat(ReadableMap options) {
-    setUserIdentity(options);
     setVisitorInfo(options);
-    setUserIdentity(options);
     String botName = getString(options,"botName");
     botName = botName == null ? "bot name" : botName;
     ChatConfiguration chatConfiguration = ChatConfiguration.builder()

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -147,10 +147,19 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
       Identity identity = new JwtIdentity(token);
       Zendesk.INSTANCE.setIdentity(identity);
     } else {
-      String name = options.getString("name");
-      String email = options.getString("email");
-      Identity identity = new AnonymousIdentity.Builder()
-        .withNameIdentifier(name).withEmailIdentifier(email).build();
+      String name = getString(options,"name");
+      String email = getString(options,"email");
+
+      AnonymousIdentity.Builder builder = new AnonymousIdentity.Builder();
+
+      if(name != null){
+          builder.withNameIdentifier(name);
+      }
+      if(email != null){
+          builder.withEmailIdentifier(email);
+      }
+
+      Identity identity = builder.build();
       Zendesk.INSTANCE.setIdentity(identity);
     }
     checkIdentity();

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -166,17 +166,28 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void openTicket(){
+      Activity activity = getCurrentActivity();
+
+      // Custom Field for the category
+      CustomField customFieldOne = new CustomField(1900002821093L, "Cashback");
+
+      // Open a ticket
+      RequestActivity.builder().
+        withCustomFields(Arrays.asList(customFieldOne)).show(activity);
+  }
+
+  @ReactMethod
+  public void showTickets(){
+      Activity activity = getCurrentActivity();
+
+      // Show the user's tickets
+      RequestListActivity.builder().show(activity);
+  }
+
+  @ReactMethod
   public void showHelpCenter(ReadableMap options) {
     Activity activity = getCurrentActivity();
-    /*
-    // config must be passed as 2nd parameter to show method
-    List<CustomField> customFields = new ArrayList<>();
-    customFields.add(new CustomField(360028434358L, "testValoreDaApp"));
-    Configuration config = RequestActivity.builder()
-      .withCustomFields(customFields)
-      .withTags("tag1","tag2")
-      .config();
-     */
     Boolean withChat = getBoolean(options,"withChat");
     Boolean disableTicketCreation = getBoolean(options,"withChat");
     if (withChat) {

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -169,12 +169,13 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
   public void openTicket(){
       Activity activity = getCurrentActivity();
 
+      List<CustomField> customFields = new ArrayList<>();
       // Custom Field for the category
-      CustomField customFieldOne = new CustomField(1900002821093L, "Cashback");
+      customFields.add(new CustomField(1900002821093L, "Cashback"));
 
       // Open a ticket
       RequestActivity.builder().
-        withCustomFields(Arrays.asList(customFieldOne)).show(activity);
+        withCustomFields(customFields).show(activity);
   }
 
   @ReactMethod

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -39,6 +39,7 @@ import zendesk.answerbot.AnswerBot;
 import zendesk.answerbot.AnswerBotEngine;
 import zendesk.support.SupportEngine;
 import zendesk.support.request.RequestActivity;
+import zendesk.support.requestlist.RequestListActivity;
 
 public class RNZendeskChat extends ReactContextBaseJavaModule {
 

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -14,6 +14,9 @@ import com.facebook.react.bridge.ReadableMap;
 import com.zendesk.logger.Logger;
 
 import java.lang.String;
+import java.util.ArrayList;
+import java.util.List;
+
 import zendesk.chat.Chat;
 import zendesk.chat.ChatConfiguration;
 import zendesk.chat.ChatEngine;
@@ -22,17 +25,20 @@ import zendesk.chat.ProfileProvider;
 import zendesk.chat.PushNotificationsProvider;
 import zendesk.chat.Providers;
 import zendesk.chat.VisitorInfo;
+import zendesk.configurations.Configuration;
 import zendesk.core.JwtIdentity;
 import zendesk.core.AnonymousIdentity;
 import zendesk.core.Identity;
 import zendesk.messaging.MessagingActivity;
 import zendesk.core.Zendesk;
+import zendesk.support.CustomField;
 import zendesk.support.Support;
 import zendesk.support.guide.HelpCenterActivity;
 import zendesk.support.guide.ViewArticleActivity;
 import zendesk.answerbot.AnswerBot;
 import zendesk.answerbot.AnswerBotEngine;
 import zendesk.support.SupportEngine;
+import zendesk.support.request.RequestActivity;
 
 public class RNZendeskChat extends ReactContextBaseJavaModule {
 
@@ -49,12 +55,21 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
     return "RNZendeskChat";
   }
 
-  private String getBotName(ReadableMap options){
-    if(options.hasKey("botName")){
-      return options.getString("botName");
+  /* helper methods */
+  private Boolean getBoolean(ReadableMap options, String key){
+    if(options.hasKey(key)){
+      return options.getBoolean(key);
     }
-    return "Chat Bot";
+    return null;
   }
+
+  private String getString(ReadableMap options, String key){
+    if(options.hasKey(key)){
+      return options.getString(key);
+    }
+    return null;
+  }
+
 
   @ReactMethod
   public void setVisitorInfo(ReadableMap options) {
@@ -75,19 +90,23 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
       return;
     }
     VisitorInfo.Builder builder = VisitorInfo.builder();
-    if (options.hasKey("name")) {
-      builder = builder.withName(options.getString("name"));
+    String name = getString(options,"name");
+    String email = getString(options,"email");
+    String phone = getString(options,"phone");
+    String department = getString(options,"department");
+    if (name != null) {
+      builder = builder.withName(name);
     }
-    if (options.hasKey("email")) {
-      builder = builder.withEmail(options.getString("email"));
+    if (email != null) {
+      builder = builder.withEmail(email);
     }
-    if (options.hasKey("phone")) {
-      builder = builder.withPhoneNumber(options.getString("phone"));
+    if (phone != null) {
+      builder = builder.withPhoneNumber(phone);
     }
     VisitorInfo visitorInfo = builder.build();
     profileProvider.setVisitorInfo(visitorInfo, null);
-    if (options.hasKey("department"))
-      chatProvider.setDepartment(options.getString("department"), null);
+    if (department != null)
+      chatProvider.setDepartment(department, null);
 
   }
 
@@ -123,8 +142,9 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void setUserIdentity(ReadableMap options) {
-    if (options.hasKey("token")) {
-      Identity identity = new JwtIdentity(options.getString("token"));
+    String token = getString(options,"token");
+    if (token != null) {
+      Identity identity = new JwtIdentity(token);
       Zendesk.INSTANCE.setIdentity(identity);
     } else {
       String name = options.getString("name");
@@ -139,11 +159,22 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
   @ReactMethod
   public void showHelpCenter(ReadableMap options) {
     Activity activity = getCurrentActivity();
-    if (options.hasKey("withChat")) {
+    /*
+    // config must be passed as 2nd parameter to show method
+    List<CustomField> customFields = new ArrayList<>();
+    customFields.add(new CustomField(360028434358L, "testValoreDaApp"));
+    Configuration config = RequestActivity.builder()
+      .withCustomFields(customFields)
+      .withTags("tag1","tag2")
+      .config();
+     */
+    Boolean withChat = getBoolean(options,"withChat");
+    Boolean disableTicketCreation = getBoolean(options,"withChat");
+    if (withChat) {
       HelpCenterActivity.builder()
         .withEngines(ChatEngine.engine())
         .show(activity);
-    } else if (options.hasKey("disableTicketCreation")) {
+    } else if (disableTicketCreation) {
       HelpCenterActivity.builder()
         .withContactUsButtonVisible(false)
         .withShowConversationsMenuButton(false)
@@ -161,7 +192,8 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
     setUserIdentity(options);
     setVisitorInfo(options);
     setUserIdentity(options);
-    String botName = getBotName(options);
+    String botName = getString(options,"botName");
+    botName = botName == null ? "bot name" : botName;
     ChatConfiguration chatConfiguration = ChatConfiguration.builder()
       .withAgentAvailabilityEnabled(true)
       .withOfflineFormEnabled(true)

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,12 @@ declare module 'io-react-native-zendesk' {
   // function to display help center UI
   export function showHelpCenter(chatOptions: ChatOptions): void;
 
+  // function to open a ticket
+  export function openTicket(): void;
+
+  // function to shows all the tickets of the user
+  export function showTickets(): void;
+
   // function to set visitor info in chat
   export function setVisitorInfo(visitorInfo: UserInfo): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,11 +50,7 @@ declare module 'io-react-native-zendesk' {
     url: string,
   }
 
-  interface UserInfo {
-    // user's name
-    name: string
-    // user's email
-    email: string
+  interface UserInfo extends AnonymousIdentity{
     // user's phone
     phone?: number
     // department to redirect the chat
@@ -69,9 +65,9 @@ declare module 'io-react-native-zendesk' {
 
   interface AnonymousIdentity {
     // user's name
-    name: string
+    name?: string
     // user's email
-    email: string
+    email?: string
   }
 
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'react-native-zendesk-v2' {
+declare module 'io-react-native-zendesk' {
 
   // function to display chat box
   export function startChat(chatOptions: ChatOptions): void;

--- a/ios/RNZendeskChat.m
+++ b/ios/RNZendeskChat.m
@@ -60,7 +60,6 @@ RCT_EXPORT_METHOD(startChat:(NSDictionary *)options) {
 }
 
 RCT_EXPORT_METHOD(openTicket) {
-  [self setVisitorInfo:options];
 
   dispatch_sync(dispatch_get_main_queue(), ^{
     [self openTicketFunction];
@@ -150,13 +149,13 @@ RCT_EXPORT_METHOD(setNotificationToken:(NSData *)deviceToken) {
     [topController presentViewController:navControl animated:YES completion:nil];
 }
 
-- (void) openTicket {
+- (void) openTicketFunction {
     UIViewController *requestList = [ZDKRequestUi buildRequestUiWith:@[]];
     UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
     while (topController.presentedViewController) {
         topController = topController.presentedViewController;
     }
-    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: controller];
+    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: requestList];
     [navControl pushViewController:requestList animated:YES];
     [topController presentViewController:navControl animated:YES completion:nil];
   }

--- a/ios/RNZendeskChat.m
+++ b/ios/RNZendeskChat.m
@@ -59,6 +59,14 @@ RCT_EXPORT_METHOD(startChat:(NSDictionary *)options) {
   });
 }
 
+RCT_EXPORT_METHOD(openTicket) {
+  [self setVisitorInfo:options];
+
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    [self openTicketFunction];
+  });
+}
+
 RCT_EXPORT_METHOD(showHelpCenter:(NSDictionary *)options) {
   [self setVisitorInfo:options];
   dispatch_sync(dispatch_get_main_queue(), ^{
@@ -141,6 +149,17 @@ RCT_EXPORT_METHOD(setNotificationToken:(NSData *)deviceToken) {
     UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: controller];
     [topController presentViewController:navControl animated:YES completion:nil];
 }
+
+- (void) openTicket {
+    UIViewController *requestList = [ZDKRequestUi buildRequestUiWith:@[]];
+    UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    while (topController.presentedViewController) {
+        topController = topController.presentedViewController;
+    }
+    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: controller];
+    [navControl pushViewController:requestList animated:YES];
+    [topController presentViewController:navControl animated:YES completion:nil];
+  }
 
 - (void) startChatFunction:(NSDictionary *)options {
     ZDKMessagingConfiguration *messagingConfiguration = [[ZDKMessagingConfiguration alloc] init];

--- a/ios/RNZendeskChat.m
+++ b/ios/RNZendeskChat.m
@@ -60,9 +60,13 @@ RCT_EXPORT_METHOD(startChat:(NSDictionary *)options) {
 }
 
 RCT_EXPORT_METHOD(openTicket) {
-
   dispatch_sync(dispatch_get_main_queue(), ^{
     [self openTicketFunction];
+  });
+}
+RCT_EXPORT_METHOD(showTickets) {
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    [self showTicketsFunction];
   });
 }
 
@@ -150,13 +154,22 @@ RCT_EXPORT_METHOD(setNotificationToken:(NSData *)deviceToken) {
 }
 
 - (void) openTicketFunction {
-    UIViewController *requestList = [ZDKRequestUi buildRequestUiWith:@[]];
+    UIViewController *openTicketController = [ZDKRequestUi buildRequestUiWith:@[]];
     UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
     while (topController.presentedViewController) {
         topController = topController.presentedViewController;
     }
-    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: requestList];
-    [navControl pushViewController:requestList animated:YES];
+    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: openTicketController];
+    [topController presentViewController:navControl animated:YES completion:nil];
+  }
+
+- (void) showTicketsFunction {
+    UIViewController *showTicketsController = [ZDKRequestUi buildRequestListWith:@[]];
+    UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    while (topController.presentedViewController) {
+        topController = topController.presentedViewController;
+    }
+    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: showTicketsController];
     [topController presentViewController:navControl animated:YES completion:nil];
   }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "zendesk unified sdkv2"
   ],
   "homepage": "https://github.com/pagopa/io-react-native-zendesk.git",
-  "author": "forked by PagoPA S.p.A - origina author @Saranshmalik",
+  "author": "forked by PagoPA S.p.A - original author @Saranshmalik",
   "license": "MIT",
   "peerDependencies": {
     "react": "~16.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-zendesk-v2",
+  "name": "io-react-native-zendesk",
   "version": "0.3.4",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zendesk-v2",
-  "version": "0.2.1",
+  "version": "0.3.4",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Saranshmalik/react-native-zendesk.git"
+    "url": "https://github.com/pagopa/io-react-native-zendesk"
   },
   "keywords": [
     "react-native",
@@ -19,8 +19,8 @@
     "chat",
     "zendesk unified sdkv2"
   ],
-  "homepage": "https://github.com/Saranshmalik/react-native-zendesk.git",
-  "author": "Saranshmalik",
+  "homepage": "https://github.com/pagopa/io-react-native-zendesk.git",
+  "author": "forked by PagoPA S.p.A - origina author @Saranshmalik",
   "license": "MIT",
   "peerDependencies": {
     "react": "~16.11.0",


### PR DESCRIPTION
## Short description
This PR adds the interface and the implementation of 2 functions that exploit the Zendesk [support package](https://developer.zendesk.com/documentation/classic-web-widget-sdks/support-sdk/android/nutshell/) instead of the [unified package](https://developer.zendesk.com/documentation/classic-web-widget-sdks/unified-sdk/android/introduction/).

## List of changes proposed in this pull request
- Added the method `openTicket` that allow a user to open a ticket
- Added the method `showTickets` that allow a user to see the list of his ticket.
- Upgraded the version to **0.3.7**



|  **openTicket** | **showTickets** |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/11773070/143250688-494e6597-8145-4bf2-98cd-902347fb838a.png" width=300>  | <img src="https://user-images.githubusercontent.com/11773070/143250727-fe2b4981-2424-488e-8d75-0d4266b455ee.png" width=300>  |

## How to test
Install the library and call the to methods with:
```
import ZendDesk from "io-react-native-zendesk";

<ButtonDefaultOpacity
        onPress={() => ZendDesk.openTicket()}
>...</ButtonDefaultOpacity>

<ButtonDefaultOpacity
        onPress={() => ZendDesk.showTickets()}
>...</ButtonDefaultOpacity>
```
